### PR TITLE
Add null value check for the return value of function s390_ipl_get_iplb_pv

### DIFF
--- a/hw/s390x/ipl.c
+++ b/hw/s390x/ipl.c
@@ -684,6 +684,8 @@ static void s390_ipl_prepare_qipl(S390CPU *cpu)
 int s390_ipl_prepare_pv_header(void)
 {
     IplParameterBlock *ipib = s390_ipl_get_iplb_pv();
+    if (!ipib)
+        return 1;
     IPLBlockPV *ipib_pv = &ipib->pv;
     void *hdr = g_malloc(ipib_pv->pv_header_len);
     int rc;
@@ -699,6 +701,8 @@ int s390_ipl_prepare_pv_header(void)
 int s390_ipl_pv_unpack(void)
 {
     IplParameterBlock *ipib = s390_ipl_get_iplb_pv();
+    if (!ipib)
+        return 1;
     IPLBlockPV *ipib_pv = &ipib->pv;
     int i, rc = 0;
 


### PR DESCRIPTION
The function `s390_ipl_get_iplb_pv` can return NULL value when `!ipl->iplb_valid_pv`. 

Although some functions, such as `handle_diag_308`, check the return value, two functions lack a null value check before dereferencing it.

To address this, we add two null value checks in `s390_ipl_pv_unpack` and `s390_ipl_prepare_pv_header`. If `s390_ipl_get_iplb_pv` returns null, these functions will return 1 to their caller, which handles the error accordingly.