### PR TITLE
Fix 2 memory leak bugs.

### DIFF
--- a/contrib/elf2dmp/main.c
+++ b/contrib/elf2dmp/main.c
@@ -125,6 +125,7 @@ static KDDEBUGGER_DATA64 *get_kdbg(uint64_t KernBase, struct pdb_reader *pdb,
 
     if (va_space_rw(vs, KdDebuggerDataBlock, kdbg, kdbg_hdr.Size, 0)) {
         eprintf("Failed to extract entire KDBG\n");
+        free(kdbg);
         return NULL;
     }
 

--- a/hw/express-gpu/egl_display_wgl.c
+++ b/hw/express-gpu/egl_display_wgl.c
@@ -156,6 +156,7 @@ void parse_pixel_format(Egl_Display *display, HDC dummy_ctx, PIXELFORMATDESCRIPT
     if (!wgl_display->wgl_ext->wglGetPixelFormatAttribivARB)
     {
         express_printf("No available wglGetPixelFormatAttribivARB\n");
+        free(config);
         return;
     }
 


### PR DESCRIPTION
In function `get_kdbg` and `parse_pixel_format`, the memory object is successfully malloced by not being freed before the function returns. Thus I add free operation before these functions return.