### PR TITLE
Fix 2 error handling branches in function main

### DIFF
--- a/contrib/elf2dmp/main.c
+++ b/contrib/elf2dmp/main.c
@@ -569,12 +569,12 @@ int main(int argc, char *argv[])
     if (fill_header(&header, &ps, &vs, KdDebuggerDataBlock, kdbg,
             KdVersionBlock, qemu_elf.state_nr)) {
         err = 1;
-        goto out_pdb;
+        goto out_kdbg;
     }
 
     if (fill_context(kdbg, &vs, &qemu_elf)) {
         err = 1;
-        goto out_pdb;
+        goto out_kdbg;
     }
 
     if (write_dump(&ps, &header, argv[2])) {


### PR DESCRIPTION
When function `fill_header` or `fill_context` fails, the program `goto out_pdb`, which doesn't free the memory allocated at  
`kdbg = get_kdbg(KernBase, &pdb, &vs, KdDebuggerDataBlock);`